### PR TITLE
fix git client's ownership issue while running pre-commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN set -eux; \
     groupadd -r tox --gid=10000; \
     useradd --no-log-init -r -g tox -m --uid=10000 tox; \
     mkdir /tests; \
-    chown tox:tox /tests
+    chown tox:tox /tests \
+    git config --system --add safe.directory /tests
 
 WORKDIR /tests
 VOLUME /tests

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,5 +14,4 @@ if [ "${1#-}" != "$1" ] || [ -n "$isLikelyTox" ]; then
 	set -- tox "$@"
 fi
 
-git config --global --add safe.directory /tests
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,4 +14,5 @@ if [ "${1#-}" != "$1" ] || [ -n "$isLikelyTox" ]; then
 	set -- tox "$@"
 fi
 
+git config --global --add safe.directory /tests
 exec "$@"


### PR DESCRIPTION
Replacement for https://github.com/pallets/flask/pull/5198

Steps to reproduce:
```
docker run -v pwd:/tests -it --rm 31z4/tox tox -e style
```

Error message 
```
 ~/newgit/github/flask   main  docker run -v `pwd`:/tests -it --rm 31z4/tox tox -e style
style: commands[0]> pre-commit run --all-files
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /home/tox/.cache/pre-commit/pre-commit.log
style: exit 1 (0.97 seconds) /tests> pre-commit run --all-files pid=15
  style: FAIL code 1 (1.11=setup[0.14]+cmd[0.97] seconds)
  evaluation failed :( (1.36 seconds)
 ✘  ~/newgit/github/flask   main 


```
log file Inside the container


```
 tox@04e24a2a1e66:/tests$ cat  /home/tox/.cache/pre-commit/pre-commit.log
### version information

pre-commit version: 3.3.3
git --version: git version 2.34.1
sys.version:
    3.11.4 (main, Jun  7 2023, 12:45:48) [GCC 11.3.0]
sys.executable: /tests/.tox/style/bin/python
os.name: posix
sys.platform: linux

### error information

An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?

Traceback (most recent call last):
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/git.py", line 58, in get_root
    cmd_output('git', 'rev-parse', '--show-cdup')[1].strip(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/util.py", line 116, in cmd_output
    returncode, stdout_b, stderr_b = cmd_output_b(*cmd, **kwargs)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/util.py", line 110, in cmd_output_b
    raise CalledProcessError(returncode, cmd, stdout_b, stderr_b)
pre_commit.util.CalledProcessError: command: ('/usr/bin/git', 'rev-parse', '--show-cdup')
return code: 128
stdout: (none)
stderr:
    fatal: detected dubious ownership in repository at '/tests'
    To add an exception for this directory, call:

    	git config --global --add safe.directory /tests

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/error_handler.py", line 73, in error_handler
    yield
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/main.py", line 370, in main
    _adjust_args_and_chdir(args)
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/main.py", line 180, in _adjust_args_and_chdir
    toplevel = git.get_root()
               ^^^^^^^^^^^^^^
  File "/tests/.tox/style/lib/python3.11/site-packages/pre_commit/git.py", line 64, in get_root
    raise FatalError(
pre_commit.errors.FatalError: git failed. Is it installed, and are you in a Git repository directory?
```

Expected result:
pre-commit should run without any git issue.

More information
https://weblog.west-wind.com/posts/2023/Jan/05/Fix-that-damn-Git-Unsafe-Repository

