### PR TITLE
Add permissions for tox user dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN set -eux; \
     groupadd -r tox --gid=10000; \
     useradd --no-log-init -r -g tox -m --uid=10000 tox; \
     mkdir /tests; \
-    chown tox:tox /tests
+    chown tox:tox /tests; \
+    chown tox:tox /home/tox
 
 WORKDIR /tests
 VOLUME /tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,8 @@ RUN set -eux; \
     pip3.11 install --no-deps -r /requirements.txt; \
     groupadd -r tox --gid=10000; \
     useradd --no-log-init -r -g tox -m --uid=10000 tox; \
-    mkdir /tests; \
-    chown tox:tox /tests; \
-    chown tox:tox /home/tox
+    mkdir /tests /home/tox/.cache; \
+    chown tox:tox /tests /home/tox/.cache
 
 WORKDIR /tests
 VOLUME /tests


### PR DESCRIPTION
Hey, 
first of all, thanks for sharing your work! 

As I’m creating a lot of runs with many dependencies, I’ve searched for a way to speed up the overall process. I think creating a dedicated caching volume might be a solution. As the current container user has only permission in the `tests`-directory, `pip` and other applications can not cache data like pypi downloads. This PR modifies the home directory of `tox`, which would allow mounting a persistend and docker managed “tox_cache” volume to every new container like: 

```bash
docker run \ 
    -u tox \ 
    -v tox_cache:/home/tox/.cache \ 
    -v `pwd`:/tests \ 
    -it \ 
    --rm \ 
    31z4/tox:latest
```